### PR TITLE
Add unit test to CI/CD Streamlit app example

### DIFF
--- a/Continuous Integration - Summit Demo/.github/workflows/main.yml
+++ b/Continuous Integration - Summit Demo/.github/workflows/main.yml
@@ -21,11 +21,18 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
-    - name: 'Install snowcli'
+    - name: 'Install snowcli and pytest environment'
       shell: bash
       run: |
         python -m pip install --upgrade pip
         pip install snowflake-cli-labs
+        pip install pytest
+        pip install streamlit==1.31 snowflake-ml-python
+    
+    - name: 'Run app tests'
+      shell: bash
+      run: |
+        pytest
 
     - name: 'Create snowsql config'
       shell: bash

--- a/Continuous Integration - Summit Demo/environment.yml
+++ b/Continuous Integration - Summit Demo/environment.yml
@@ -2,6 +2,6 @@ name: sf_env
 channels:
   - snowflake
 dependencies:
-  - streamlit
+  - streamlit=1.31
   - snowflake-snowpark-python
   - snowflake-ml-python

--- a/Continuous Integration - Summit Demo/streamlit_app.py
+++ b/Continuous Integration - Summit Demo/streamlit_app.py
@@ -1,20 +1,10 @@
 import streamlit as st
 import numpy as np
-from snowflake.snowpark.context import get_active_session
 from snowflake.cortex import Complete
 import pandas as pd
 
 st.set_page_config(layout="wide")
 
-
-def is_local() -> bool:
-    """
-    Check if app is running locally, by checking if the user email is a local one.
-
-    Returns:
-        bool: True if running locally, else (if in SiS) False.
-    """
-    return st.experimental_user.email in {"test@localhost.com", "test@example.com"}
 
 @st.cache_data
 def generate_fake_data_for_demo(seed=36) -> pd.DataFrame:
@@ -39,17 +29,12 @@ def generate_fake_data_for_demo(seed=36) -> pd.DataFrame:
     return df
 
 
-st.title(f"❄️ Streamlit in Snowflake Key Metrics (dummy data) ❄️")
+st.title("❄️ Streamlit in Snowflake Key Metrics (dummy data) ❄️")
 st.sidebar.image(
     "https://upload.wikimedia.org/wikipedia/commons/f/ff/Snowflake_Logo.svg"
 )
 
-if is_local():
-    conn = st.connection("snowflake")
-    session = conn.session()
-
-else:
-    session = get_active_session()
+session = st.connection('snowflake').session()
 
 df = generate_fake_data_for_demo()
 

--- a/Continuous Integration - Summit Demo/streamlit_test.py
+++ b/Continuous Integration - Summit Demo/streamlit_test.py
@@ -11,8 +11,8 @@ class MockSnowparkDF:
         return self.df
 
 
-# @patch replaces the streamlit.connection with a MagicMock, the conn argument to test_app()
-# This enables mocking the Snowflake sql() call. See:
+# @patch replaces the Snowflake calls with MagicMocks passed as arguments
+# This enables mocking the Snowflake sql() and Complete() calls. See:
 # https://docs.python.org/3/library/unittest.mock.html#quick-guide
 @patch("snowflake.cortex.Complete")
 @patch("streamlit.connection")

--- a/Continuous Integration - Summit Demo/streamlit_test.py
+++ b/Continuous Integration - Summit Demo/streamlit_test.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+from streamlit.testing.v1 import AppTest
+import pandas as pd
+
+
+class MockSnowparkDF:
+    def __init__(self, df):
+        self.df = df
+
+    def to_pandas(self):
+        return self.df
+
+
+# @patch replaces the streamlit.connection with a MagicMock, the conn argument to test_app()
+# This enables mocking the Snowflake sql() call. See:
+# https://docs.python.org/3/library/unittest.mock.html#quick-guide
+@patch("snowflake.cortex.Complete")
+@patch("streamlit.connection")
+def test_app(conn, complete):
+    """Test the app output"""
+    at = AppTest.from_file("streamlit_app.py")
+
+    # Set up the mocks
+    user_feedback = pd.DataFrame({
+        "TIMESTAMP": ["2022-01-01", "2022-01-02", "2022-01-03"],
+        "FEEDBACK": [
+            "Streamlit in Snowflake has revolutionized our data visualization process ...",
+            "I appreciate the integration of Streamlit in Snowflake, ...",
+            "Streamlit in Snowflake is powerful, but ..."
+        ],
+        "USER_ID": ["user7", "user1", "user3"],
+    })
+    
+    # app calls st.connection().session().sql()
+    conn.return_value.session.return_value.sql.return_value = MockSnowparkDF(user_feedback)
+
+    # Ensure the DF ends up in call to Complete, and return a dummy response
+    DUMMY_RESPONSE = "Users love Streamlit in Snowflake, while some want more integrations"
+    def complete_response(model, prompt, session):
+        assert model == "mistral-large"
+        assert "Streamlit in Snowflake has revolutionized our data visualization process" in prompt
+        return DUMMY_RESPONSE
+    complete.side_effect = complete_response
+
+    # Run the script and compare results
+    at.run()
+    # print(at) # use for debugging
+
+    # Sections display in proper order
+    assert at.subheader[0].value == "Number of customers"
+    assert at.subheader[1].value == "Views per day"
+    assert at.subheader[2].value == "Views per customer"
+    
+    # Dummy response was returned and rendered as markdown
+    assert at.markdown[-1].value == DUMMY_RESPONSE
+    
+    # No exceptions
+    assert not at.exception


### PR DESCRIPTION
This pull request primarily focuses on enhancing the Continuous Integration (CI) pipeline for the Summit Demo project and simplifying the codebase of the Streamlit application. The major modifications include the addition of a pytest environment and test cases, version pinning for Streamlit, and the removal of redundant code.

Updates to the CI pipeline:

* [`Continuous Integration - Summit Demo/.github/workflows/main.yml`](diffhunk://#diff-17e7f830cd37756cec5d35b78d8e518f17909418cee2cf2d9482d0b56ab43559L24-R35): The CI pipeline now installs pytest and specific versions of streamlit and snowflake-ml-python. It also includes a new step to run tests using pytest.

Streamlit version pinning:

* [`Continuous Integration - Summit Demo/environment.yml`](diffhunk://#diff-830a7431621471ba2f3a484ec2c87331eb608c9ea096c3edf71e88718a823da0L5-R5): The Streamlit version has been pinned to 1.31 in the environment configuration.

Codebase simplification:

* [`Continuous Integration - Summit Demo/streamlit_app.py`](diffhunk://#diff-5123d07fbd278c8bc217c5bf904fa65884ae0bd16d739f1bafc08d95b7a46fd0L3-L18): The `is_local` function and related code have been removed, simplifying the session initiation process. The title string has been simplified as well. [[1]](diffhunk://#diff-5123d07fbd278c8bc217c5bf904fa65884ae0bd16d739f1bafc08d95b7a46fd0L3-L18) [[2]](diffhunk://#diff-5123d07fbd278c8bc217c5bf904fa65884ae0bd16d739f1bafc08d95b7a46fd0L42-R37)

Test cases addition:

* [`Continuous Integration - Summit Demo/streamlit_test.py`](diffhunk://#diff-60d64b86bd78665063f6f73f0969be8200a85b889833d12fc015ba2bb2347932R1-R58): A new test file has been added, which includes a mock class `MockSnowparkDF` and a function `test_app` to test the Streamlit application. This function uses mocked responses to test the application's output.