### PR TITLE
llm chat model comparison: pin streamlit version to fix container height kwarg

### DIFF
--- a/LLM Chat Model Comparison/environment.yml
+++ b/LLM Chat Model Comparison/environment.yml
@@ -3,3 +3,4 @@ channels:
   - snowflake
 dependencies:
   - snowflake-ml-python
+  - streamlit=1.35.0


### PR DESCRIPTION
Currently creating STREAMLIT directly from the git repo will cause app to fail starting because it may default to a version of streamlit without `height` argument for `st.container`.

This change pins the streamlit version to the latest currently available which fixes the error.