### PR TITLE
Updates for H3 Mapping and Timeseries Visualization example 

### DIFF
--- a/H3 Mapping and Timeseries Visualization/environment.yml
+++ b/H3 Mapping and Timeseries Visualization/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - pydeck=0.8.0
   - python=3.8.*
   - snowflake-snowpark-python
-  - streamlit=1.26
+  - streamlit=1.29

--- a/H3 Mapping and Timeseries Visualization/streamlit_app.py
+++ b/H3 Mapping and Timeseries Visualization/streamlit_app.py
@@ -4,7 +4,6 @@ import pandas as pd
 import plotly.express as px
 import pydeck as pdk
 import streamlit as st
-from snowflake.snowpark.context import get_active_session
 
 
 @st.cache_data
@@ -20,7 +19,7 @@ def get_dataframe_from_raw_sql(query: str) -> pd.DataFrame:
         pd.DataFrame: The query result as a pandas dataframe.
     """
     # Get active session to query the Snowflake database
-    session = get_active_session()
+    session = st.connection("snowflake").session()
     pandas_df = session.sql(query).to_pandas()
     return pandas_df
 
@@ -107,7 +106,9 @@ def render_plotly_line_chart(chart_df: pd.DataFrame):
     )
 
 
-st.set_page_config(layout="wide", initial_sidebar_state="expanded")
+st.set_page_config(
+    page_title="NY Pickup Location App", layout="wide", initial_sidebar_state="expanded"
+)
 st.title("NY Pickup Location App :taxi:")
 st.write(
     """An app that visualizes geo-temporal data from NY taxi pickups using H3 and time series. 


### PR DESCRIPTION
Update H3 Mapping and Timeseries Visualization to 
- work both on https://share.streamlit.io and SiS
  - bump streamlit to 1.29 - it's the first version with st.connection support on SiS
  - use st.connection("snowflake").session() for retrieving session which works on CC and SiS
 - set page_title so that it's indexed on CC correctly
   - I didn't spot any negative consequences of this on SiS
 
Deployed app on Community Cloud https://app-demo-app-5nwiq953zzj6jugwcxnxvt.streamlit.app/
  