### PR TITLE
Add sis embedding samples

### DIFF
--- a/Embedding Streamlit in Snowflake/.gitignore
+++ b/Embedding Streamlit in Snowflake/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.env.local
+*.pem
+*.p8
+*.tsbuildinfo
+next-env.d.ts
+.DS_Store
+snowflake.log
+package-lock.json
+*.pub

--- a/Embedding Streamlit in Snowflake/README.md
+++ b/Embedding Streamlit in Snowflake/README.md
@@ -46,75 +46,13 @@ Only two files carry the real logic in each app:
 - `app/api/embed-url/route.ts` — connects to Snowflake and runs the system function.
 - `app/page.tsx` — fetches `/api/embed-url` and drops the result into an `<iframe>`.
 
-## One-time Snowflake setup (all methods)
+## Snowflake setup
 
-Run as `ACCOUNTADMIN`. Two things must be true: the minting role holds `USAGE` on the
-app, and the parent origin is on the embedding allow-list.
+Before running a sample, complete the one-time account setup — enabling the
+embedding feature, allow-listing your parent origin, and creating the minting
+role and per-method credentials (PAT, key-pair JWT, or WIF). See the docs:
 
-```sql
--- Allow-list the origin your page is served from
-ALTER ACCOUNT SET STREAMLIT_EMBEDDING_CONTROLS = $$
-allowed_embedding_domains:
-  - https://your-domain.com
-$$;
-
--- Minting role needs USAGE on the app + its DB/schema + a warehouse
-CREATE ROLE IF NOT EXISTS embed_minter;
-GRANT USAGE ON DATABASE  streamlit_apps            TO ROLE embed_minter;
-GRANT USAGE ON SCHEMA    streamlit_apps.public     TO ROLE embed_minter;
-GRANT USAGE ON STREAMLIT streamlit_apps.public.my_app TO ROLE embed_minter;
-GRANT USAGE ON WAREHOUSE embed_wh                  TO ROLE embed_minter;
-```
-
-## Per-method credential setup
-
-### PAT (`examples/pat`)
-
-```sql
-CREATE USER IF NOT EXISTS embed_svc TYPE = SERVICE;
-GRANT ROLE embed_minter TO USER embed_svc;
-ALTER USER embed_svc SET DEFAULT_ROLE = embed_minter;
-
-ALTER USER embed_svc ADD PROGRAMMATIC ACCESS TOKEN embed_pat
-  ROLE_RESTRICTION = 'EMBED_MINTER' DAYS_TO_EXPIRY = 90;
--- copy the token_secret into SNOWFLAKE_PAT
-```
-
-### Key-Pair JWT (`examples/keypair`)
-
-```bash
-# Generate an encrypted RSA key pair
-openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 aes-256-cbc -inform PEM -out rsa_key.p8
-openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
-```
-
-```sql
-CREATE USER IF NOT EXISTS embed_svc TYPE = SERVICE;
-GRANT ROLE embed_minter TO USER embed_svc;
-ALTER USER embed_svc SET DEFAULT_ROLE = embed_minter;
-ALTER USER embed_svc SET RSA_PUBLIC_KEY = 'MIIB... (contents of rsa_key.pub)';
--- point SNOWFLAKE_PRIVATE_KEY_PATH at rsa_key.p8
-```
-
-### Workload Identity Federation — OIDC (`examples/wif`)
-
-The workload's identity is the OIDC JWT you place in `SNOWFLAKE_WIF_TOKEN`; there is
-no client-side username. Map the token's issuer/subject to a Snowflake user:
-
-```sql
-CREATE USER IF NOT EXISTS embed_svc TYPE = SERVICE
-  WORKLOAD_IDENTITY = (
-    TYPE = OIDC
-    ISSUER = 'https://your-idp.example.com'
-    SUBJECT = 'your-workload-subject'
-  );
-GRANT ROLE embed_minter TO USER embed_svc;
-ALTER USER embed_svc SET DEFAULT_ROLE = embed_minter;
-```
-
-> WIF authenticates using a live federated token, so it runs in the cloud environment
-> that issues it (or wherever you can supply a valid OIDC JWT) — not from a static
-> local secret.
+[Embed a Streamlit in Snowflake app](https://docs.snowflake.com/en/LIMITEDACCESS/streamlit/embed-streamlit-app)
 
 ## Run any sample
 

--- a/Embedding Streamlit in Snowflake/README.md
+++ b/Embedding Streamlit in Snowflake/README.md
@@ -1,0 +1,151 @@
+# Streamlit-in-Snowflake embedding samples
+
+Three minimal, copy-paste-ready Next.js apps that embed a **Streamlit-in-Snowflake**
+app in an `<iframe>`. Each folder is identical except for **how it authenticates to
+Snowflake** to mint the embed URL:
+
+| Folder                | Auth method                       | Best for                                  |
+| --------------------- | --------------------------------- | ----------------------------------------- |
+| `examples/pat`        | Programmatic Access Token (PAT)   | Simplest setup, service users             |
+| `examples/keypair`    | Key-Pair JWT                      | Rotating RSA keys, no shared secrets      |
+| `examples/wif`        | Workload Identity Federation (OIDC) | Cloud workloads with a federated JWT     |
+| `examples/plain-node` | PAT, no framework                 | Zero-dependency reference (Node http + static HTML) |
+
+The first three are Next.js (App Router). `plain-node` is the same flow with no
+framework — a Node `http` server that mints the URL and serves one static HTML page —
+for anyone who wants the bare mechanics without React. It uses PAT; swap the
+`createConnection` config in `server.mjs` to use Key-Pair or WIF (see the routes in the
+other folders).
+
+## How it works
+
+```
+Browser  ──GET /api/embed-url──▶  Next.js server (auth to Snowflake)
+                                      │  SELECT SYSTEM$STREAMLIT_GENERATE_EMBED_URL(app, parent_origin)
+                                      ▼
+                                 { embed_url }
+Browser  ◀──{ embedUrl }───────  server
+   │
+   └──▶  <iframe src={embedUrl} />
+```
+
+The embed URL is minted **server-side** and is **single-use** — the client mints one
+per load and never caches it (`dynamic = "force-dynamic"`).
+
+Only two files carry the real logic in each app:
+- `app/api/embed-url/route.ts` — connects to Snowflake and runs the system function.
+- `app/page.tsx` — fetches `/api/embed-url` and drops the result into an `<iframe>`.
+
+## One-time Snowflake setup (all methods)
+
+Run as `ACCOUNTADMIN`. Two things must be true: the minting role holds `USAGE` on the
+app, and the parent origin is on the embedding allow-list.
+
+```sql
+-- Allow-list the origin your page is served from
+ALTER ACCOUNT SET STREAMLIT_EMBEDDING_CONTROLS = $$
+allowed_embedding_domains:
+  - https://your-domain.com
+$$;
+
+-- Minting role needs USAGE on the app + its DB/schema + a warehouse
+CREATE ROLE IF NOT EXISTS embed_minter;
+GRANT USAGE ON DATABASE  streamlit_apps            TO ROLE embed_minter;
+GRANT USAGE ON SCHEMA    streamlit_apps.public     TO ROLE embed_minter;
+GRANT USAGE ON STREAMLIT streamlit_apps.public.my_app TO ROLE embed_minter;
+GRANT USAGE ON WAREHOUSE embed_wh                  TO ROLE embed_minter;
+```
+
+## Per-method credential setup
+
+### PAT (`examples/pat`)
+
+```sql
+CREATE USER IF NOT EXISTS embed_svc TYPE = SERVICE;
+GRANT ROLE embed_minter TO USER embed_svc;
+ALTER USER embed_svc SET DEFAULT_ROLE = embed_minter;
+
+ALTER USER embed_svc ADD PROGRAMMATIC ACCESS TOKEN embed_pat
+  ROLE_RESTRICTION = 'EMBED_MINTER' DAYS_TO_EXPIRY = 90;
+-- copy the token_secret into SNOWFLAKE_PAT
+```
+
+### Key-Pair JWT (`examples/keypair`)
+
+```bash
+# Generate an encrypted RSA key pair
+openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 aes-256-cbc -inform PEM -out rsa_key.p8
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+```sql
+CREATE USER IF NOT EXISTS embed_svc TYPE = SERVICE;
+GRANT ROLE embed_minter TO USER embed_svc;
+ALTER USER embed_svc SET DEFAULT_ROLE = embed_minter;
+ALTER USER embed_svc SET RSA_PUBLIC_KEY = 'MIIB... (contents of rsa_key.pub)';
+-- point SNOWFLAKE_PRIVATE_KEY_PATH at rsa_key.p8
+```
+
+### Workload Identity Federation — OIDC (`examples/wif`)
+
+The workload's identity is the OIDC JWT you place in `SNOWFLAKE_WIF_TOKEN`; there is
+no client-side username. Map the token's issuer/subject to a Snowflake user:
+
+```sql
+CREATE USER IF NOT EXISTS embed_svc TYPE = SERVICE
+  WORKLOAD_IDENTITY = (
+    TYPE = OIDC
+    ISSUER = 'https://your-idp.example.com'
+    SUBJECT = 'your-workload-subject'
+  );
+GRANT ROLE embed_minter TO USER embed_svc;
+ALTER USER embed_svc SET DEFAULT_ROLE = embed_minter;
+```
+
+> WIF authenticates using a live federated token, so it runs in the cloud environment
+> that issues it (or wherever you can supply a valid OIDC JWT) — not from a static
+> local secret.
+
+## Run any sample
+
+```bash
+cd examples/pat        # or keypair, or wif
+npm install
+cp .env.example .env.local   # fill in your values
+npm run dev                  # http://localhost:3000
+```
+
+The `plain-node` variant is the same but framework-free (env is loaded by Node's
+built-in `--env-file`, so it needs Node 20.6+):
+
+```bash
+cd examples/plain-node
+npm install
+cp .env.example .env.local   # fill in your values
+npm start                    # http://localhost:3000
+```
+
+### Serving from the allow-listed origin (required for the iframe to load)
+
+The iframe's `postMessage` lifecycle uses `PARENT_ORIGIN` as its target, so the page
+must be served from **exactly** that origin. For local HTTPS testing:
+
+```bash
+brew install mkcert && mkcert -install
+mkcert your-domain.com localhost 127.0.0.1
+echo "127.0.0.1 your-domain.com" | sudo tee -a /etc/hosts
+
+sudo $(which npx) next dev --port 443 --hostname your-domain.com \
+  --experimental-https \
+  --experimental-https-key ./your-domain.com+2-key.pem \
+  --experimental-https-cert ./your-domain.com+2.pem
+```
+
+## Checklist / gotchas
+
+- `ENABLE_STREAMLIT_EMBEDDING_FEATURE = true` on the account.
+- Minting role has `USAGE` on the app + DB + schema (missing USAGE looks like
+  *"object does not exist"*, not a permission error).
+- `PARENT_ORIGIN` is in `allowed_embedding_domains` **and** is the exact origin the
+  browser loads the page from.
+- Don't cache the embed URL — one is minted per load.

--- a/Embedding Streamlit in Snowflake/README.md
+++ b/Embedding Streamlit in Snowflake/README.md
@@ -1,8 +1,8 @@
 # Streamlit-in-Snowflake embedding samples
 
-Three minimal, copy-paste-ready Next.js apps that embed a **Streamlit-in-Snowflake**
-app in an `<iframe>`. Each folder is identical except for **how it authenticates to
-Snowflake** to mint the embed URL:
+Minimal, copy-paste-ready examples that embed a **Streamlit-in-Snowflake**
+app in an `<iframe>`. Each `examples/` folder is identical except for **how it
+authenticates to Snowflake** to mint the embed URL:
 
 | Folder                | Auth method                       | Best for                                  |
 | --------------------- | --------------------------------- | ----------------------------------------- |
@@ -11,11 +11,16 @@ Snowflake** to mint the embed URL:
 | `examples/wif`        | Workload Identity Federation (OIDC) | Cloud workloads with a federated JWT     |
 | `examples/plain-node` | PAT, no framework                 | Zero-dependency reference (Node http + static HTML) |
 
-The first three are Next.js (App Router). `plain-node` is the same flow with no
-framework — a Node `http` server that mints the URL and serves one static HTML page —
-for anyone who wants the bare mechanics without React. It uses PAT; swap the
-`createConnection` config in `server.mjs` to use Key-Pair or WIF (see the routes in the
-other folders).
+`pat`, `keypair`, and `wif` are Next.js (App Router). `plain-node` is the same
+flow with no framework — a Node `http` server that mints the URL and serves one
+static HTML page — for anyone who wants the bare mechanics without React. It uses
+PAT; swap the `createConnection` config in `server.mjs` to use Key-Pair or WIF
+(see the routes in the other folders).
+
+The `demo/` folder is a fuller example: a styled analytics portal (Next.js) that
+embeds the Streamlit app as a live panel, using the same PAT flow. Start with an
+`examples/` folder to learn the mechanics; look at `demo/` to see it in a
+realistic UI.
 
 ## How it works
 
@@ -31,6 +36,11 @@ Browser  ◀──{ embedUrl }───────  server
 
 The embed URL is minted **server-side** and is **single-use** — the client mints one
 per load and never caches it (`dynamic = "force-dynamic"`).
+
+Each app reuses **one long-lived Snowflake connection** across requests (see
+`getConnection` in the route). The embed code is bound to the session that minted
+it, so that session must stay alive until the browser redeems the code — opening
+and closing a connection per request causes the embed to fail with a `401`.
 
 Only two files carry the real logic in each app:
 - `app/api/embed-url/route.ts` — connects to Snowflake and runs the system function.

--- a/Embedding Streamlit in Snowflake/demo/.env.example
+++ b/Embedding Streamlit in Snowflake/demo/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env.local and fill in. Never commit .env.local.
+
+SNOWFLAKE_ACCOUNT=MYORG-MYACCT
+SNOWFLAKE_USER=embed_svc
+SNOWFLAKE_PAT=replace-with-your-pat-secret
+SNOWFLAKE_ROLE=embed_minter
+SNOWFLAKE_WAREHOUSE=embed_wh
+
+STREAMLIT_APP=STREAMLIT_APPS.PUBLIC.MY_APP
+PARENT_ORIGIN=https://your-domain.com

--- a/Embedding Streamlit in Snowflake/demo/.gitignore
+++ b/Embedding Streamlit in Snowflake/demo/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.env.local
+*.pem
+*.p8
+snowflake.log
+package-lock.json

--- a/Embedding Streamlit in Snowflake/demo/app/api/embed-url/route.ts
+++ b/Embedding Streamlit in Snowflake/demo/app/api/embed-url/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server"
+import snowflake from "snowflake-sdk"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+// The embed code is bound to the session that minted it, so reuse one
+// long-lived connection rather than opening one per request.
+let connPromise: Promise<snowflake.Connection> | null = null
+
+function getConnection(): Promise<snowflake.Connection> {
+  if (connPromise) return connPromise
+  connPromise = new Promise((resolve, reject) => {
+    const conn = snowflake.createConnection({
+      account: process.env.SNOWFLAKE_ACCOUNT!,
+      username: process.env.SNOWFLAKE_USER!,
+      authenticator: "PROGRAMMATIC_ACCESS_TOKEN",
+      token: process.env.SNOWFLAKE_PAT!,
+      role: process.env.SNOWFLAKE_ROLE,
+      warehouse: process.env.SNOWFLAKE_WAREHOUSE,
+    })
+    conn.connect((err) => (err ? reject(err) : resolve(conn)))
+  })
+  connPromise.catch(() => (connPromise = null))
+  return connPromise
+}
+
+export async function GET() {
+  try {
+    const conn = await getConnection()
+    return NextResponse.json({ embedUrl: await mintEmbedUrl(conn) })
+  } catch (e) {
+    connPromise = null
+    return NextResponse.json({ error: (e as Error).message }, { status: 500 })
+  }
+}
+
+function mintEmbedUrl(conn: snowflake.Connection): Promise<string> {
+  const app = process.env.STREAMLIT_APP!.replace(/'/g, "''")
+  const origin = process.env.PARENT_ORIGIN!.replace(/'/g, "''")
+  return new Promise((resolve, reject) => {
+    conn.execute({
+      sqlText: `SELECT SYSTEM$STREAMLIT_GENERATE_EMBED_URL('${app}', '${origin}')`,
+      complete: (err, _stmt, rows) => {
+        if (err) return reject(err)
+        resolve(JSON.parse(Object.values(rows![0])[0] as string).embed_url)
+      },
+    })
+  })
+}

--- a/Embedding Streamlit in Snowflake/demo/app/globals.css
+++ b/Embedding Streamlit in Snowflake/demo/app/globals.css
@@ -1,0 +1,234 @@
+:root {
+  --brand: #4f46e5;
+  --brand-dark: #4338ca;
+  --brand-soft: #eef2ff;
+  --ink: #0f172a;
+  --ink-soft: #64748b;
+  --ink-faint: #94a3b8;
+  --line: #e2e8f0;
+  --bg: #f8fafc;
+  --card: #ffffff;
+  --ok: #059669;
+  --ok-soft: #ecfdf5;
+  --danger: #dc2626;
+  --radius: 12px;
+  --shadow: 0 1px 2px rgba(15, 23, 42, 0.06), 0 8px 24px rgba(15, 23, 42, 0.05);
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; height: 100%; }
+body {
+  font-family: var(--font);
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+button { font-family: inherit; }
+
+.shell { display: flex; flex-direction: column; height: 100vh; }
+
+/* Top bar */
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  height: 60px;
+  padding: 0 22px;
+  background: var(--card);
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+}
+.brand { display: flex; align-items: center; gap: 11px; font-weight: 650; font-size: 16px; }
+.logo {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  background: linear-gradient(135deg, var(--brand), #7c3aed);
+  color: #fff;
+  font-weight: 700;
+}
+.brand span { color: var(--ink-faint); font-weight: 500; }
+.topnav { display: flex; gap: 4px; margin-left: 20px; height: 100%; }
+.topnav a {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 13px;
+  font-size: 14px;
+  color: var(--ink-soft);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+}
+.topnav a:hover { color: var(--ink); }
+.topnav a.active { color: var(--brand); border-bottom-color: var(--brand); font-weight: 600; }
+.user { display: flex; align-items: center; gap: 10px; margin-left: auto; }
+.avatar {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--brand-soft);
+  color: var(--brand);
+  font-size: 13px;
+  font-weight: 700;
+}
+.user-meta { display: flex; flex-direction: column; line-height: 1.25; }
+.user-meta .name { font-size: 13px; font-weight: 600; }
+.user-meta .role { font-size: 11px; color: var(--ink-soft); }
+
+/* Body */
+.body { display: flex; flex: 1; min-height: 0; }
+.sidebar {
+  width: 236px;
+  flex-shrink: 0;
+  background: var(--card);
+  border-right: 1px solid var(--line);
+  padding: 18px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.nav-label {
+  padding: 14px 10px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 9px 11px;
+  border-radius: 9px;
+  font-size: 14px;
+  color: var(--ink-soft);
+  text-decoration: none;
+  cursor: pointer;
+}
+.nav-item:hover { background: var(--bg); color: var(--ink); }
+.nav-item.active { background: var(--brand-soft); color: var(--brand); font-weight: 600; }
+.dot-icon { width: 8px; height: 8px; border-radius: 50%; background: currentColor; flex-shrink: 0; opacity: 0.55; }
+.nav-item.active .dot-icon { opacity: 1; }
+
+/* Content */
+.content { flex: 1; min-width: 0; overflow-y: auto; padding: 24px 30px; display: flex; flex-direction: column; gap: 20px; }
+.page-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+.page-head h1 { margin: 0; font-size: 24px; font-weight: 700; letter-spacing: -0.3px; }
+.page-head .sub { margin-top: 5px; font-size: 14px; color: var(--ink-soft); }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--card);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn:hover { background: var(--bg); }
+.btn-primary { background: var(--brand); border-color: var(--brand); color: #fff; }
+.btn-primary:hover { background: var(--brand-dark); }
+
+/* KPIs */
+.kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 18px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+.kpi .label { font-size: 13px; color: var(--ink-soft); }
+.kpi .val { font-size: 26px; font-weight: 700; letter-spacing: -0.6px; }
+.kpi .delta { font-size: 12px; font-weight: 600; }
+.kpi .delta.up { color: var(--ok); }
+.kpi .delta.down { color: var(--danger); }
+
+/* Embed card */
+.embed-card {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 520px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.embed-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--line);
+}
+.embed-title { font-size: 14px; font-weight: 600; }
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ok);
+  background: var(--ok-soft);
+}
+.live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ok);
+  animation: pulse 1.8s infinite;
+}
+.embed-head .spacer { margin-left: auto; }
+.link-btn {
+  border: none;
+  background: transparent;
+  color: var(--ink-soft);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 7px;
+}
+.link-btn:hover { background: var(--bg); color: var(--ink); }
+.embed-body { position: relative; flex: 1; min-height: 0; background: #fff; }
+.embed-body iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: none; }
+.embed-state {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  text-align: center;
+  color: var(--ink-soft);
+  font-size: 14px;
+}
+.embed-state .btn { margin-top: 4px; }
+
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(5, 150, 105, 0.5); }
+  70% { box-shadow: 0 0 0 6px rgba(5, 150, 105, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(5, 150, 105, 0); }
+}
+
+@media (max-width: 1100px) { .kpis { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 900px) { .sidebar, .topnav, .user-meta { display: none; } }
+@media (max-width: 640px) { .kpis { grid-template-columns: 1fr; } .content { padding: 18px; } }

--- a/Embedding Streamlit in Snowflake/demo/app/layout.tsx
+++ b/Embedding Streamlit in Snowflake/demo/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+import "./globals.css"
+
+export const metadata: Metadata = {
+  title: "ACME Analytics — Sales Performance",
+  description: "Analytics portal with a Streamlit-in-Snowflake dashboard embedded as a live panel.",
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/Embedding Streamlit in Snowflake/demo/app/page.tsx
+++ b/Embedding Streamlit in Snowflake/demo/app/page.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+const TOP_NAV = ["Dashboards", "Reports", "Data Catalog", "Admin"]
+
+const SIDEBAR = [
+  { group: "Dashboards", items: ["Executive Overview", "Sales Performance", "Inventory", "Aftersales"] },
+  { group: "Tools", items: ["Data Explorer", "Reports", "Alerts"] },
+]
+
+const ACTIVE = "Sales Performance"
+
+const KPIS = [
+  { label: "Units Sold (MTD)", val: "48,210", delta: "+6.4%", up: true },
+  { label: "Revenue (MTD)", val: "$2.91B", delta: "+3.1%", up: true },
+  { label: "Avg. Selling Price", val: "$60,380", delta: "-1.2%", up: false },
+  { label: "Active Dealers", val: "3,742", delta: "+0.8%", up: true },
+]
+
+export default function Page() {
+  const [embedUrl, setEmbedUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const minted = useRef(false) // embed code is single-use; mint once (StrictMode guard)
+
+  const loadEmbed = useCallback(() => {
+    setError(null)
+    setEmbedUrl(null)
+    fetch("/api/embed-url")
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((d) => setEmbedUrl(d.embedUrl))
+      .catch(() => setError("Could not reach the analytics service."))
+  }, [])
+
+  useEffect(() => {
+    if (minted.current) return
+    minted.current = true
+    loadEmbed()
+  }, [loadEmbed])
+
+  return (
+    <div className="shell">
+      <header className="topbar">
+        <div className="brand">
+          <span className="logo">A</span>
+          ACME <span>Analytics</span>
+        </div>
+        <nav className="topnav">
+          {TOP_NAV.map((item) => (
+            <a key={item} href="#" className={item === "Dashboards" ? "active" : ""}>
+              {item}
+            </a>
+          ))}
+        </nav>
+        <div className="user">
+          <div className="avatar">MK</div>
+          <div className="user-meta">
+            <span className="name">Mara Klein</span>
+            <span className="role">Sales Analytics</span>
+          </div>
+        </div>
+      </header>
+
+      <div className="body">
+        <aside className="sidebar">
+          {SIDEBAR.map(({ group, items }) => (
+            <div key={group}>
+              <div className="nav-label">{group}</div>
+              {items.map((name) => (
+                <a key={name} href="#" className={`nav-item${name === ACTIVE ? " active" : ""}`}>
+                  <span className="dot-icon" />
+                  {name}
+                </a>
+              ))}
+            </div>
+          ))}
+        </aside>
+
+        <main className="content">
+          <div className="page-head">
+            <div>
+              <h1>Sales Performance</h1>
+              <div className="sub">Live vehicle sales and revenue analytics across global markets</div>
+            </div>
+          </div>
+
+          <div className="kpis">
+            {KPIS.map((k) => (
+              <div className="kpi" key={k.label}>
+                <span className="label">{k.label}</span>
+                <span className="val">{k.val}</span>
+                <span className={`delta ${k.up ? "up" : "down"}`}>{k.delta} vs. last month</span>
+              </div>
+            ))}
+          </div>
+
+          <section className="embed-card">
+            <div className="embed-head">
+              <span className="embed-title">Sales Intelligence</span>
+              <span className="badge">
+                <span className="live-dot" />
+                Live · Streamlit in Snowflake
+              </span>
+              <div className="spacer" />
+              <button className="link-btn" onClick={loadEmbed}>
+                Refresh
+              </button>
+            </div>
+            <div className="embed-body">
+              {error ? (
+                <div className="embed-state">
+                  {error}
+                  <button className="btn btn-primary" onClick={loadEmbed}>
+                    Try again
+                  </button>
+                </div>
+              ) : embedUrl ? (
+                <iframe
+                  src={embedUrl}
+                  title="Embedded Streamlit App"
+                  allow="clipboard-read; clipboard-write; fullscreen"
+                />
+              ) : (
+                <div className="embed-state">Loading…</div>
+              )}
+            </div>
+          </section>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/Embedding Streamlit in Snowflake/demo/next.config.mjs
+++ b/Embedding Streamlit in Snowflake/demo/next.config.mjs
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+export default {}

--- a/Embedding Streamlit in Snowflake/demo/package.json
+++ b/Embedding Streamlit in Snowflake/demo/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sis-embed-demo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "snowflake-sdk": "^2.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^5"
+  }
+}

--- a/Embedding Streamlit in Snowflake/demo/tsconfig.json
+++ b/Embedding Streamlit in Snowflake/demo/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/Embedding Streamlit in Snowflake/examples/keypair/.env.example
+++ b/Embedding Streamlit in Snowflake/examples/keypair/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env.local and fill in. Never commit .env.local or your private key.
+
+SNOWFLAKE_ACCOUNT=MYORG-MYACCT
+SNOWFLAKE_USER=embed_svc
+SNOWFLAKE_PRIVATE_KEY_PATH=/absolute/path/to/rsa_key.p8
+SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=your-key-passphrase
+SNOWFLAKE_ROLE=embed_minter
+SNOWFLAKE_WAREHOUSE=embed_wh
+
+STREAMLIT_APP=STREAMLIT_APPS.PUBLIC.MY_APP
+PARENT_ORIGIN=https://your-domain.com

--- a/Embedding Streamlit in Snowflake/examples/keypair/.gitignore
+++ b/Embedding Streamlit in Snowflake/examples/keypair/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+.env.local
+*.pem
+*.p8

--- a/Embedding Streamlit in Snowflake/examples/keypair/app/api/embed-url/route.ts
+++ b/Embedding Streamlit in Snowflake/examples/keypair/app/api/embed-url/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server"
+import snowflake from "snowflake-sdk"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+// The embed code is bound to the session that minted it, so reuse one
+// long-lived connection rather than opening one per request.
+let connPromise: Promise<snowflake.Connection> | null = null
+
+function getConnection(): Promise<snowflake.Connection> {
+  if (connPromise) return connPromise
+  connPromise = new Promise((resolve, reject) => {
+    const conn = snowflake.createConnection({
+      account: process.env.SNOWFLAKE_ACCOUNT!,
+      username: process.env.SNOWFLAKE_USER!,
+      authenticator: "SNOWFLAKE_JWT",
+      privateKeyPath: process.env.SNOWFLAKE_PRIVATE_KEY_PATH!,
+      privateKeyPass: process.env.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, // omit if key is unencrypted
+      role: process.env.SNOWFLAKE_ROLE,
+      warehouse: process.env.SNOWFLAKE_WAREHOUSE,
+    })
+    conn.connect((err) => (err ? reject(err) : resolve(conn)))
+  })
+  connPromise.catch(() => (connPromise = null))
+  return connPromise
+}
+
+export async function GET() {
+  try {
+    const conn = await getConnection()
+    return NextResponse.json({ embedUrl: await mintEmbedUrl(conn) })
+  } catch (e) {
+    connPromise = null
+    return NextResponse.json({ error: (e as Error).message }, { status: 500 })
+  }
+}
+
+function mintEmbedUrl(conn: snowflake.Connection): Promise<string> {
+  const app = process.env.STREAMLIT_APP!.replace(/'/g, "''")
+  const origin = process.env.PARENT_ORIGIN!.replace(/'/g, "''")
+  return new Promise((resolve, reject) => {
+    conn.execute({
+      sqlText: `SELECT SYSTEM$STREAMLIT_GENERATE_EMBED_URL('${app}', '${origin}')`,
+      complete: (err, _stmt, rows) => {
+        if (err) return reject(err)
+        resolve(JSON.parse(Object.values(rows![0])[0] as string).embed_url)
+      },
+    })
+  })
+}

--- a/Embedding Streamlit in Snowflake/examples/keypair/app/layout.tsx
+++ b/Embedding Streamlit in Snowflake/examples/keypair/app/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = { title: "SiS Embed — Key-Pair JWT" }
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0 }}>{children}</body>
+    </html>
+  )
+}

--- a/Embedding Streamlit in Snowflake/examples/keypair/app/page.tsx
+++ b/Embedding Streamlit in Snowflake/examples/keypair/app/page.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+export default function Page() {
+  const [url, setUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const requested = useRef(false)
+
+  useEffect(() => {
+    if (requested.current) return // embed URL is single-use; mint once
+    requested.current = true
+    fetch("/api/embed-url")
+      .then((r) => r.json())
+      .then((d) => (d.embedUrl ? setUrl(d.embedUrl) : setError(d.error)))
+      .catch((e) => setError(String(e)))
+  }, [])
+
+  if (error) return <p style={{ padding: 24, fontFamily: "system-ui" }}>Error: {error}</p>
+  if (!url) return <p style={{ padding: 24, fontFamily: "system-ui" }}>Loading…</p>
+  return (
+    <iframe
+      src={url}
+      title="Streamlit in Snowflake"
+      allow="clipboard-read; clipboard-write; fullscreen"
+      style={{ border: 0, width: "100vw", height: "100vh" }}
+    />
+  )
+}

--- a/Embedding Streamlit in Snowflake/examples/keypair/next.config.mjs
+++ b/Embedding Streamlit in Snowflake/examples/keypair/next.config.mjs
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+export default {}

--- a/Embedding Streamlit in Snowflake/examples/keypair/package.json
+++ b/Embedding Streamlit in Snowflake/examples/keypair/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sis-embed-keypair",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "snowflake-sdk": "^2.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^5"
+  }
+}

--- a/Embedding Streamlit in Snowflake/examples/keypair/tsconfig.json
+++ b/Embedding Streamlit in Snowflake/examples/keypair/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/Embedding Streamlit in Snowflake/examples/pat/.env.example
+++ b/Embedding Streamlit in Snowflake/examples/pat/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env.local and fill in. Never commit .env.local.
+
+SNOWFLAKE_ACCOUNT=MYORG-MYACCT
+SNOWFLAKE_USER=embed_svc
+SNOWFLAKE_PAT=replace-with-your-pat-secret
+SNOWFLAKE_ROLE=embed_minter
+SNOWFLAKE_WAREHOUSE=embed_wh
+
+STREAMLIT_APP=STREAMLIT_APPS.PUBLIC.MY_APP
+PARENT_ORIGIN=https://your-domain.com

--- a/Embedding Streamlit in Snowflake/examples/pat/.gitignore
+++ b/Embedding Streamlit in Snowflake/examples/pat/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+.env.local
+*.pem
+*.p8

--- a/Embedding Streamlit in Snowflake/examples/pat/app/api/embed-url/route.ts
+++ b/Embedding Streamlit in Snowflake/examples/pat/app/api/embed-url/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server"
+import snowflake from "snowflake-sdk"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+// The embed code is bound to the session that minted it, so reuse one
+// long-lived connection rather than opening one per request.
+let connPromise: Promise<snowflake.Connection> | null = null
+
+function getConnection(): Promise<snowflake.Connection> {
+  if (connPromise) return connPromise
+  connPromise = new Promise((resolve, reject) => {
+    const conn = snowflake.createConnection({
+      account: process.env.SNOWFLAKE_ACCOUNT!,
+      username: process.env.SNOWFLAKE_USER!,
+      authenticator: "PROGRAMMATIC_ACCESS_TOKEN",
+      token: process.env.SNOWFLAKE_PAT!,
+      role: process.env.SNOWFLAKE_ROLE,
+      warehouse: process.env.SNOWFLAKE_WAREHOUSE,
+    })
+    conn.connect((err) => (err ? reject(err) : resolve(conn)))
+  })
+  connPromise.catch(() => (connPromise = null))
+  return connPromise
+}
+
+export async function GET() {
+  try {
+    const conn = await getConnection()
+    return NextResponse.json({ embedUrl: await mintEmbedUrl(conn) })
+  } catch (e) {
+    connPromise = null
+    return NextResponse.json({ error: (e as Error).message }, { status: 500 })
+  }
+}
+
+function mintEmbedUrl(conn: snowflake.Connection): Promise<string> {
+  const app = process.env.STREAMLIT_APP!.replace(/'/g, "''")
+  const origin = process.env.PARENT_ORIGIN!.replace(/'/g, "''")
+  return new Promise((resolve, reject) => {
+    conn.execute({
+      sqlText: `SELECT SYSTEM$STREAMLIT_GENERATE_EMBED_URL('${app}', '${origin}')`,
+      complete: (err, _stmt, rows) => {
+        if (err) return reject(err)
+        resolve(JSON.parse(Object.values(rows![0])[0] as string).embed_url)
+      },
+    })
+  })
+}

--- a/Embedding Streamlit in Snowflake/examples/pat/app/layout.tsx
+++ b/Embedding Streamlit in Snowflake/examples/pat/app/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = { title: "SiS Embed — PAT" }
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0 }}>{children}</body>
+    </html>
+  )
+}

--- a/Embedding Streamlit in Snowflake/examples/pat/app/page.tsx
+++ b/Embedding Streamlit in Snowflake/examples/pat/app/page.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+export default function Page() {
+  const [url, setUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const requested = useRef(false)
+
+  useEffect(() => {
+    if (requested.current) return // embed URL is single-use; mint once
+    requested.current = true
+    fetch("/api/embed-url")
+      .then((r) => r.json())
+      .then((d) => (d.embedUrl ? setUrl(d.embedUrl) : setError(d.error)))
+      .catch((e) => setError(String(e)))
+  }, [])
+
+  if (error) return <p style={{ padding: 24, fontFamily: "system-ui" }}>Error: {error}</p>
+  if (!url) return <p style={{ padding: 24, fontFamily: "system-ui" }}>Loading…</p>
+  return (
+    <iframe
+      src={url}
+      title="Streamlit in Snowflake"
+      allow="clipboard-read; clipboard-write; fullscreen"
+      style={{ border: 0, width: "100vw", height: "100vh" }}
+    />
+  )
+}

--- a/Embedding Streamlit in Snowflake/examples/pat/next.config.mjs
+++ b/Embedding Streamlit in Snowflake/examples/pat/next.config.mjs
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+export default {}

--- a/Embedding Streamlit in Snowflake/examples/pat/package.json
+++ b/Embedding Streamlit in Snowflake/examples/pat/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sis-embed-pat",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "snowflake-sdk": "^2.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^5"
+  }
+}

--- a/Embedding Streamlit in Snowflake/examples/pat/tsconfig.json
+++ b/Embedding Streamlit in Snowflake/examples/pat/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/Embedding Streamlit in Snowflake/examples/plain-node/.env.example
+++ b/Embedding Streamlit in Snowflake/examples/plain-node/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env.local and fill in. Never commit .env.local.
+
+SNOWFLAKE_ACCOUNT=MYORG-MYACCT
+SNOWFLAKE_USER=embed_svc
+SNOWFLAKE_PAT=replace-with-your-pat-secret
+SNOWFLAKE_ROLE=embed_minter
+SNOWFLAKE_WAREHOUSE=embed_wh
+
+STREAMLIT_APP=STREAMLIT_APPS.PUBLIC.MY_APP
+PARENT_ORIGIN=https://your-domain.com

--- a/Embedding Streamlit in Snowflake/examples/plain-node/.gitignore
+++ b/Embedding Streamlit in Snowflake/examples/plain-node/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env.local
+*.pem
+*.p8

--- a/Embedding Streamlit in Snowflake/examples/plain-node/index.html
+++ b/Embedding Streamlit in Snowflake/examples/plain-node/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>SiS Embed — Plain Node</title>
+    <style>
+      html, body { margin: 0; height: 100% }
+      iframe { border: 0; width: 100vw; height: 100vh }
+      #msg { padding: 24px; font-family: system-ui }
+    </style>
+  </head>
+  <body>
+    <p id="msg">Loading…</p>
+    <script>
+      fetch("/api/embed-url")
+        .then((r) => r.json())
+        .then((d) => {
+          if (!d.embedUrl) throw new Error(d.error)
+          const f = document.createElement("iframe")
+          f.src = d.embedUrl
+          f.title = "Streamlit in Snowflake"
+          f.allow = "clipboard-read; clipboard-write; fullscreen"
+          document.body.replaceChildren(f)
+        })
+        .catch((e) => { document.getElementById("msg").textContent = "Error: " + e.message })
+    </script>
+  </body>
+</html>

--- a/Embedding Streamlit in Snowflake/examples/plain-node/package.json
+++ b/Embedding Streamlit in Snowflake/examples/plain-node/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sis-embed-plain-node",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node --env-file=.env.local server.mjs"
+  },
+  "dependencies": {
+    "snowflake-sdk": "^2.4.3"
+  }
+}

--- a/Embedding Streamlit in Snowflake/examples/plain-node/server.mjs
+++ b/Embedding Streamlit in Snowflake/examples/plain-node/server.mjs
@@ -1,0 +1,59 @@
+import { createServer } from "node:http"
+import { readFile } from "node:fs/promises"
+import snowflake from "snowflake-sdk"
+
+const PORT = process.env.PORT || 3000
+
+// The embed code is bound to the session that minted it, so reuse one
+// long-lived connection rather than opening one per request.
+let connPromise = null
+
+function getConnection() {
+  if (connPromise) return connPromise
+  connPromise = new Promise((resolve, reject) => {
+    const conn = snowflake.createConnection({
+      account: process.env.SNOWFLAKE_ACCOUNT,
+      username: process.env.SNOWFLAKE_USER,
+      authenticator: "PROGRAMMATIC_ACCESS_TOKEN",
+      token: process.env.SNOWFLAKE_PAT,
+      role: process.env.SNOWFLAKE_ROLE,
+      warehouse: process.env.SNOWFLAKE_WAREHOUSE,
+    })
+    conn.connect((err) => (err ? reject(err) : resolve(conn)))
+  })
+  connPromise.catch(() => (connPromise = null))
+  return connPromise
+}
+
+function mintEmbedUrl(conn) {
+  const app = process.env.STREAMLIT_APP.replace(/'/g, "''")
+  const origin = process.env.PARENT_ORIGIN.replace(/'/g, "''")
+  return new Promise((resolve, reject) => {
+    conn.execute({
+      sqlText: `SELECT SYSTEM$STREAMLIT_GENERATE_EMBED_URL('${app}', '${origin}')`,
+      complete: (err, _stmt, rows) => {
+        if (err) return reject(err)
+        resolve(JSON.parse(Object.values(rows[0])[0]).embed_url)
+      },
+    })
+  })
+}
+
+createServer(async (req, res) => {
+  if (req.url === "/api/embed-url") {
+    try {
+      const conn = await getConnection()
+      const embedUrl = await mintEmbedUrl(conn)
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(JSON.stringify({ embedUrl }))
+    } catch (e) {
+      connPromise = null
+      res.writeHead(500, { "content-type": "application/json" })
+      res.end(JSON.stringify({ error: e.message }))
+    }
+    return
+  }
+  const html = await readFile(new URL("./index.html", import.meta.url))
+  res.writeHead(200, { "content-type": "text/html" })
+  res.end(html)
+}).listen(PORT, () => console.log(`http://localhost:${PORT}`))

--- a/Embedding Streamlit in Snowflake/examples/wif/.env.example
+++ b/Embedding Streamlit in Snowflake/examples/wif/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env.local and fill in. Never commit .env.local.
+# OIDC WIF: the workload's identity is carried in the JWT (SNOWFLAKE_WIF_TOKEN),
+# so no SNOWFLAKE_USER is set here. Map the token's subject to a Snowflake user
+# with WORKLOAD IDENTITY on the account (see repo README).
+
+SNOWFLAKE_ACCOUNT=MYORG-MYACCT
+SNOWFLAKE_WIF_TOKEN=replace-with-your-oidc-jwt
+SNOWFLAKE_ROLE=embed_minter
+SNOWFLAKE_WAREHOUSE=embed_wh
+
+STREAMLIT_APP=STREAMLIT_APPS.PUBLIC.MY_APP
+PARENT_ORIGIN=https://your-domain.com

--- a/Embedding Streamlit in Snowflake/examples/wif/.gitignore
+++ b/Embedding Streamlit in Snowflake/examples/wif/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+.env.local
+*.pem
+*.p8

--- a/Embedding Streamlit in Snowflake/examples/wif/app/api/embed-url/route.ts
+++ b/Embedding Streamlit in Snowflake/examples/wif/app/api/embed-url/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server"
+import snowflake from "snowflake-sdk"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+// The embed code is bound to the session that minted it, so reuse one
+// long-lived connection rather than opening one per request.
+let connPromise: Promise<snowflake.Connection> | null = null
+
+function getConnection(): Promise<snowflake.Connection> {
+  if (connPromise) return connPromise
+  connPromise = new Promise((resolve, reject) => {
+    const conn = snowflake.createConnection({
+      account: process.env.SNOWFLAKE_ACCOUNT!,
+      authenticator: "WORKLOAD_IDENTITY",
+      workloadIdentityProvider: "OIDC",
+      token: process.env.SNOWFLAKE_WIF_TOKEN!,
+      role: process.env.SNOWFLAKE_ROLE,
+      warehouse: process.env.SNOWFLAKE_WAREHOUSE,
+    })
+    conn.connect((err) => (err ? reject(err) : resolve(conn)))
+  })
+  connPromise.catch(() => (connPromise = null))
+  return connPromise
+}
+
+export async function GET() {
+  try {
+    const conn = await getConnection()
+    return NextResponse.json({ embedUrl: await mintEmbedUrl(conn) })
+  } catch (e) {
+    connPromise = null
+    return NextResponse.json({ error: (e as Error).message }, { status: 500 })
+  }
+}
+
+function mintEmbedUrl(conn: snowflake.Connection): Promise<string> {
+  const app = process.env.STREAMLIT_APP!.replace(/'/g, "''")
+  const origin = process.env.PARENT_ORIGIN!.replace(/'/g, "''")
+  return new Promise((resolve, reject) => {
+    conn.execute({
+      sqlText: `SELECT SYSTEM$STREAMLIT_GENERATE_EMBED_URL('${app}', '${origin}')`,
+      complete: (err, _stmt, rows) => {
+        if (err) return reject(err)
+        resolve(JSON.parse(Object.values(rows![0])[0] as string).embed_url)
+      },
+    })
+  })
+}

--- a/Embedding Streamlit in Snowflake/examples/wif/app/layout.tsx
+++ b/Embedding Streamlit in Snowflake/examples/wif/app/layout.tsx
@@ -1,0 +1,9 @@
+export const metadata = { title: "SiS Embed — Workload Identity (OIDC)" }
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0 }}>{children}</body>
+    </html>
+  )
+}

--- a/Embedding Streamlit in Snowflake/examples/wif/app/page.tsx
+++ b/Embedding Streamlit in Snowflake/examples/wif/app/page.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+export default function Page() {
+  const [url, setUrl] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const requested = useRef(false)
+
+  useEffect(() => {
+    if (requested.current) return // embed URL is single-use; mint once
+    requested.current = true
+    fetch("/api/embed-url")
+      .then((r) => r.json())
+      .then((d) => (d.embedUrl ? setUrl(d.embedUrl) : setError(d.error)))
+      .catch((e) => setError(String(e)))
+  }, [])
+
+  if (error) return <p style={{ padding: 24, fontFamily: "system-ui" }}>Error: {error}</p>
+  if (!url) return <p style={{ padding: 24, fontFamily: "system-ui" }}>Loading…</p>
+  return (
+    <iframe
+      src={url}
+      title="Streamlit in Snowflake"
+      allow="clipboard-read; clipboard-write; fullscreen"
+      style={{ border: 0, width: "100vw", height: "100vh" }}
+    />
+  )
+}

--- a/Embedding Streamlit in Snowflake/examples/wif/next.config.mjs
+++ b/Embedding Streamlit in Snowflake/examples/wif/next.config.mjs
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+export default {}

--- a/Embedding Streamlit in Snowflake/examples/wif/package.json
+++ b/Embedding Streamlit in Snowflake/examples/wif/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sis-embed-wif",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "snowflake-sdk": "^2.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^5"
+  }
+}

--- a/Embedding Streamlit in Snowflake/examples/wif/tsconfig.json
+++ b/Embedding Streamlit in Snowflake/examples/wif/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds a new **Embedding Streamlit in Snowflake** folder with minimal,
copy-paste-ready examples that embed a Streamlit-in-Snowflake app in an
`<iframe>` from an external web app. Each `examples/` folder is identical
except for how it authenticates to Snowflake to mint the embed URL:

| Folder                | Auth method                          |
| --------------------- | ------------------------------------ |
| `examples/pat`        | Programmatic Access Token (PAT)      |
| `examples/keypair`    | Key-Pair JWT                         |
| `examples/wif`        | Workload Identity Federation (OIDC)  |
| `examples/plain-node` | PAT, no framework (Node http + HTML) |

A `demo/` folder shows the same PAT flow inside a fuller, styled analytics
portal UI.

## How it works

The server mints an embed URL via `SYSTEM$STREAMLIT_GENERATE_EMBED_URL(app,
parent_origin)` and returns it to the browser, which drops it into an iframe.
The URL is minted server-side and is single-use (one per page load).

## Key design note

Each route reuses **one long-lived Snowflake connection** rather than opening
and closing one per request. The embed code is bound to the session that minted
it, so that session must stay alive until the browser redeems the code at
`/_stcore/embed/token` — a per-request connection that's destroyed immediately
causes the embed to fail with a `401`.
